### PR TITLE
Clarify output directory usage in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ Convert video files into SCORM 1.2 compliant packages.
 
 ## Usage
 ```
-scorm-scorcher <video-file> <output-directory>
+scorm-scorcher <video-file> --output-dir <dir>
 ```
+
+The output directory is optional and defaults to `output/`.
 
 This project is in early development and many features are placeholders.


### PR DESCRIPTION
## Summary
- document `--output-dir` flag in usage example
- note default `output/` directory

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68b1fe8b50808332bb6b90ce297627c4