### PR TITLE
Add package version and top-level API exports

### DIFF
--- a/src/scorm_scorcher/__init__.py
+++ b/src/scorm_scorcher/__init__.py
@@ -1,0 +1,20 @@
+"""Top-level package for ``scorm_scorcher``.
+
+This module exposes high-level APIs for convenience and defines the
+package's version.
+"""
+
+__version__ = "0.1.0"
+
+from .video_processing import process_video
+from .scorm_packager import create_scorm_package
+
+__all__ = ["process_video", "create_scorm_package", "__version__"]
+
+# Optional imports that require extra dependencies
+try:  # pragma: no cover - optional feature
+    from .quiz_generation import generate_quiz_from_markdown, save_quiz_to_json
+except Exception:  # ModuleNotFoundError if optional deps missing
+    pass
+else:
+    __all__ += ["generate_quiz_from_markdown", "save_quiz_to_json"]


### PR DESCRIPTION
## Summary
- Expose high-level APIs at package root for easier imports
- Define `__version__` and `__all__` in package initializer
- Handle optional quiz generation exports when dependencies are missing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68b1fe914e908332aff7b7cc0fd01bcf