### PR TITLE
Ensure ffmpeg presence before processing video

### DIFF
--- a/src/scorm_scorcher/video_processing.py
+++ b/src/scorm_scorcher/video_processing.py
@@ -1,9 +1,18 @@
 """Video processing utilities."""
 
 from pathlib import Path
+import shutil
+import subprocess
+
 
 def process_video(video_path: str) -> None:
-    """Placeholder function for processing the video.
+    """Basic processing of a video file.
+
+    The function currently validates the input file and runs ``ffmpeg`` in a
+    way that verifies the file can be read.  ``ffmpeg`` is a required external
+    dependency, so the function checks that it is available before attempting
+    to run it.  Any errors from the command are surfaced with their stderr
+    output to aid in debugging.
 
     Args:
         video_path: Path to the input video file.
@@ -11,5 +20,23 @@ def process_video(video_path: str) -> None:
     path = Path(video_path)
     if not path.exists():
         raise FileNotFoundError(f"Video file not found: {video_path}")
-    # TODO: implement segmentation, subtitle generation, etc.
+
+    if shutil.which("ffmpeg") is None:
+        raise EnvironmentError("ffmpeg is required but was not found on the system PATH")
+
+    # Run ffmpeg to validate the video. ``-f null -`` avoids creating output.
+    cmd = [
+        "ffmpeg",
+        "-v",
+        "error",
+        "-i",
+        str(path),
+        "-f",
+        "null",
+        "-",
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        stderr = result.stderr.strip() or "Unknown ffmpeg error"
+        raise RuntimeError(f"ffmpeg failed to process '{video_path}': {stderr}")
     print(f"Processing video: {video_path}")


### PR DESCRIPTION
## Summary
- validate ffmpeg is installed before attempting video processing
- capture ffmpeg stderr and raise a clear error if processing fails

## Testing
- `python -m pytest`
- `python -m compileall src/scorm_scorcher`


------
https://chatgpt.com/codex/tasks/task_b_68b1fe9b5cec83329db627bd5906339d