### PR TITLE
Handle OpenAI import and API key errors in quiz generator

### DIFF
--- a/src/scorm_scorcher/quiz_generation.py
+++ b/src/scorm_scorcher/quiz_generation.py
@@ -1,10 +1,9 @@
 """Quiz generation using OpenAI API."""
 
 import json
+import os
 from pathlib import Path
 from typing import List, Dict
-
-import openai
 
 
 class QuizQuestion(Dict[str, str]):
@@ -18,6 +17,20 @@ def generate_quiz_from_markdown(md_path: str, num_questions: int = 5) -> List[Qu
         md_path: Path to the markdown file containing transcript.
         num_questions: Number of quiz questions to generate.
     """
+    try:
+        import openai
+    except ImportError as exc:
+        raise ImportError(
+            "The 'openai' package is required to generate quizzes. "
+            "Install it with 'pip install openai'."
+        ) from exc
+
+    api_key = os.getenv("OPENAI_API_KEY") or getattr(openai, "api_key", None)
+    if not api_key:
+        raise ValueError(
+            "OpenAI API key is missing. Set the OPENAI_API_KEY environment variable."
+        )
+
     path = Path(md_path)
     if not path.exists():
         raise FileNotFoundError(f"Markdown file not found: {md_path}")


### PR DESCRIPTION
## Summary
- Import `openai` within `generate_quiz_from_markdown` to avoid hard dependency
- Provide clear error messages when the OpenAI package or API key is missing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68b1fea4bbb48332bce1c1573d3b85fa