### PR TITLE
Implement ffmpeg-based video processing and tests

### DIFF
--- a/src/scorm_scorcher/cli.py
+++ b/src/scorm_scorcher/cli.py
@@ -20,10 +20,10 @@ def main(video_path: str, output_dir: str) -> None:
     """Convert VIDEO_PATH into a SCORM package."""
 
     try:
-        process_video(video_path)
-
         out_dir = Path(output_dir)
         out_dir.mkdir(parents=True, exist_ok=True)
+
+        process_video(video_path, str(out_dir))
         output_zip = out_dir / "scorm_package.zip"
         create_scorm_package(str(out_dir), str(output_zip))
         click.echo(f"Created SCORM package at {output_zip}")

--- a/src/scorm_scorcher/video_processing.py
+++ b/src/scorm_scorcher/video_processing.py
@@ -1,40 +1,117 @@
-"""Video processing utilities."""
+"""Video processing utilities using ``ffmpeg``.
+
+This module extracts audio, subtitles and segments a video file.  The
+intermediate artefacts are written to a working directory so they can be used
+later when creating the SCORM package.
+"""
+
+from __future__ import annotations
 
 from pathlib import Path
 import shutil
 import subprocess
+from typing import Dict, List
 
 
-def process_video(video_path: str) -> None:
-    """Basic processing of a video file.
+def _run_ffmpeg(cmd: List[str]) -> None:
+    """Run an ``ffmpeg`` command raising :class:`RuntimeError` on failure."""
+
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        stderr = result.stderr.strip() or "Unknown ffmpeg error"
+        raise RuntimeError(f"ffmpeg command failed: {stderr}")
+
+
+def process_video(
+    video_path: str, work_dir: str, segment_duration: int = 360
+) -> Dict[str, object]:
+    """Process ``video_path`` writing artefacts to ``work_dir``.
 
     Args:
         video_path: Path to the input video file.
+        work_dir: Directory where intermediate artefacts will be written.
+        segment_duration: Length in seconds for each video segment.
+
+    Returns:
+        A dictionary with keys ``audio``, ``subtitles`` and ``segments``.  Each
+        value is a path or list of paths to the generated artefacts.
 
     Raises:
         FileNotFoundError: If the video file does not exist.
         EnvironmentError: If ``ffmpeg`` is not available.
         RuntimeError: If ``ffmpeg`` fails to process the file.
     """
-    path = Path(video_path)
-    if not path.exists():
+
+    src = Path(video_path)
+    if not src.exists():
         raise FileNotFoundError(f"Video file not found: {video_path}")
+
+    out_dir = Path(work_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
 
     if shutil.which("ffmpeg") is None:
         raise EnvironmentError("ffmpeg is required but was not found on the system PATH")
 
-    cmd = [
+    # --- Extract audio ---
+    audio_path = out_dir / "audio.mp3"
+    audio_cmd = [
         "ffmpeg",
         "-v",
         "error",
         "-i",
-        str(path),
-        "-f",
-        "null",
-        "-",
+        str(src),
+        "-vn",
+        "-acodec",
+        "mp3",
+        str(audio_path),
     ]
-    result = subprocess.run(cmd, capture_output=True, text=True)
-    if result.returncode != 0:
-        stderr = result.stderr.strip() or "Unknown ffmpeg error"
-        raise RuntimeError(f"ffmpeg failed to process '{video_path}': {stderr}")
-    print(f"Processing video: {video_path}")
+    _run_ffmpeg(audio_cmd)
+
+    # --- Extract subtitles (if available) ---
+    subtitles_path = out_dir / "subtitles.vtt"
+    subtitles_cmd = [
+        "ffmpeg",
+        "-v",
+        "error",
+        "-i",
+        str(src),
+        "-map",
+        "0:s:0?",
+        "-f",
+        "webvtt",
+        str(subtitles_path),
+    ]
+    _run_ffmpeg(subtitles_cmd)
+
+    # --- Segment video ---
+    segment_template = out_dir / "segment_%03d.mp4"
+    segment_cmd = [
+        "ffmpeg",
+        "-v",
+        "error",
+        "-i",
+        str(src),
+        "-map",
+        "0",
+        "-c",
+        "copy",
+        "-f",
+        "segment",
+        "-segment_time",
+        str(segment_duration),
+        "-reset_timestamps",
+        "1",
+        str(segment_template),
+    ]
+    _run_ffmpeg(segment_cmd)
+
+    segments = sorted(out_dir.glob("segment_*.mp4"))
+    if not segments:
+        raise RuntimeError("ffmpeg did not produce any segments")
+
+    return {
+        "audio": str(audio_path),
+        "subtitles": str(subtitles_path),
+        "segments": [str(p) for p in segments],
+    }
+

--- a/tests/test_video_processing.py
+++ b/tests/test_video_processing.py
@@ -1,20 +1,67 @@
 import subprocess
+from pathlib import Path
+from typing import List
 from unittest.mock import patch
+
+import pytest
 
 from scorm_scorcher.video_processing import process_video
 
 
-def test_process_video_calls_ffmpeg(tmp_path):
+def _fake_run_factory(tmp_path: Path):
+    """Create a ``subprocess.run`` replacement writing expected artefacts."""
+
+    def _fake_run(cmd: List[str], capture_output: bool = True, text: bool = True):
+        output = Path(cmd[-1])
+        if "segment" in cmd:
+            # create two dummy segments
+            (tmp_path / "segment_000.mp4").write_text("seg0")
+            (tmp_path / "segment_001.mp4").write_text("seg1")
+        else:
+            output.write_text("data")
+        return subprocess.CompletedProcess(args=cmd, returncode=0)
+
+    return _fake_run
+
+
+def test_process_video_success(tmp_path):
     video_file = tmp_path / "video.mp4"
     video_file.write_text("data")
 
     with patch("scorm_scorcher.video_processing.shutil.which", return_value="ffmpeg"), \
         patch("scorm_scorcher.video_processing.subprocess.run") as mock_run:
-        mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=0)
-        process_video(str(video_file))
+        mock_run.side_effect = _fake_run_factory(tmp_path)
+        artefacts = process_video(str(video_file), str(tmp_path))
 
-    mock_run.assert_called_once_with(
-        ["ffmpeg", "-v", "error", "-i", str(video_file), "-f", "null", "-"],
-        capture_output=True,
-        text=True,
-    )
+    assert Path(artefacts["audio"]).is_file()
+    assert Path(artefacts["subtitles"]).is_file()
+    assert len(artefacts["segments"]) == 2
+    assert mock_run.call_count == 3
+
+
+def test_process_video_missing_file(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        process_video(str(tmp_path / "missing.mp4"), str(tmp_path))
+
+
+def test_process_video_missing_ffmpeg(tmp_path):
+    video_file = tmp_path / "video.mp4"
+    video_file.write_text("data")
+
+    with patch("scorm_scorcher.video_processing.shutil.which", return_value=None):
+        with pytest.raises(EnvironmentError):
+            process_video(str(video_file), str(tmp_path))
+
+
+def test_process_video_ffmpeg_failure(tmp_path):
+    video_file = tmp_path / "video.mp4"
+    video_file.write_text("data")
+
+    with patch("scorm_scorcher.video_processing.shutil.which", return_value="ffmpeg"), \
+        patch(
+            "scorm_scorcher.video_processing.subprocess.run",
+            return_value=subprocess.CompletedProcess(args=[], returncode=1, stderr="boom"),
+        ):
+        with pytest.raises(RuntimeError):
+            process_video(str(video_file), str(tmp_path))
+


### PR DESCRIPTION
## Summary
- Expand `process_video` to extract audio, subtitles, and 360s segments using ffmpeg
- Store intermediate artifacts and return their paths for packaging
- Update CLI and add comprehensive unit tests for success and failure cases

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68b21499f07c83328b88f9ce2c87b003