### PR TITLE
Require SCORM manifest when packaging

### DIFF
--- a/src/scorm_scorcher/scorm_packager.py
+++ b/src/scorm_scorcher/scorm_packager.py
@@ -10,6 +10,10 @@ def create_scorm_package(source_dir: str, output_zip: str) -> None:
     if not src.is_dir():
         raise NotADirectoryError(f"Source directory not found: {source_dir}")
 
+    manifest = src / "imsmanifest.xml"
+    if not manifest.is_file():
+        raise FileNotFoundError("imsmanifest.xml not found in source directory")
+
     with ZipFile(output_zip, "w", compression=ZIP_DEFLATED) as zf:
         for file in src.rglob("*"):
             zf.write(file, file.relative_to(src))

--- a/tests/test_scorm_packager.py
+++ b/tests/test_scorm_packager.py
@@ -1,17 +1,33 @@
 from zipfile import ZipFile
 
+import pytest
+
 from scorm_scorcher.scorm_packager import create_scorm_package
+
+
+def _write_manifest(src):
+    (src / "imsmanifest.xml").write_text("<manifest></manifest>")
 
 
 def test_create_scorm_package(tmp_path):
     src = tmp_path / "src"
     src.mkdir()
     (src / "file.txt").write_text("hello")
+    _write_manifest(src)
     output = tmp_path / "package.zip"
 
     create_scorm_package(str(src), str(output))
 
     assert output.exists()
     with ZipFile(output) as zf:
-        assert zf.namelist() == ["file.txt"]
+        assert sorted(zf.namelist()) == ["file.txt", "imsmanifest.xml"]
         assert zf.read("file.txt").decode() == "hello"
+
+
+def test_create_scorm_package_missing_manifest(tmp_path):
+    src = tmp_path / "src"
+    src.mkdir()
+    output = tmp_path / "package.zip"
+
+    with pytest.raises(FileNotFoundError):
+        create_scorm_package(str(src), str(output))


### PR DESCRIPTION
## Summary
- Ensure `create_scorm_package` checks for `imsmanifest.xml`
- Add tests for SCORM package creation and missing manifest

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68b21b2115248332b2f6b34edef3fd7f