### PR TITLE
test: add cli and quiz saving tests

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,36 @@
+from zipfile import ZipFile
+
+from click.testing import CliRunner
+
+from scorm_scorcher.cli import main
+
+
+def test_cli_creates_scorm_package(tmp_path, monkeypatch):
+    video = tmp_path / "video.mp4"
+    video.write_text("data")
+    out_dir = tmp_path / "output"
+
+    calls = {}
+
+    def fake_process_video(video_path, output_dir):
+        calls["process_video"] = (video_path, output_dir)
+
+    def fake_create_scorm_package(src, output_zip):
+        calls["create_scorm_package"] = (src, output_zip)
+        with ZipFile(output_zip, "w") as zf:
+            zf.writestr("dummy.txt", "hello")
+
+    monkeypatch.setattr("scorm_scorcher.cli.process_video", fake_process_video)
+    monkeypatch.setattr("scorm_scorcher.cli.create_scorm_package", fake_create_scorm_package)
+
+    runner = CliRunner()
+    result = runner.invoke(main, [str(video), "--output-dir", str(out_dir)])
+
+    assert result.exit_code == 0
+    zip_path = out_dir / "scorm_package.zip"
+    assert zip_path.exists()
+    with ZipFile(zip_path) as zf:
+        assert zf.namelist() == ["dummy.txt"]
+    assert calls["process_video"] == (str(video), str(out_dir))
+    assert calls["create_scorm_package"] == (str(out_dir), str(zip_path))
+    assert f"Created SCORM package at {zip_path}" in result.output

--- a/tests/test_quiz_generation.py
+++ b/tests/test_quiz_generation.py
@@ -47,3 +47,22 @@ def test_save_quiz_to_json(tmp_path):
 
     data = json.loads(out.read_text())
     assert data == [{"question": "Q?", "choices": ["A", "B"], "answer": "A"}]
+
+
+def test_generate_quiz_and_save(monkeypatch, tmp_path):
+    md = tmp_path / "transcript.md"
+    md.write_text("content")
+
+    data = [
+        {"question": "Q1?", "choices": ["A", "B"], "answer": "A"},
+        {"question": "Q2?", "choices": ["C", "D"], "answer": "D"},
+    ]
+
+    monkeypatch.setenv("OPENAI_API_KEY", "x")
+    monkeypatch.setitem(sys.modules, "openai", _fake_openai_module(data))
+
+    questions = generate_quiz_from_markdown(str(md), num_questions=2)
+    out = tmp_path / "quiz.json"
+    save_quiz_to_json(questions, str(out))
+
+    assert json.loads(out.read_text()) == data


### PR DESCRIPTION
## Summary
- add CLI test using `CliRunner` validating SCORM package creation
- verify quiz generation integration saves output when OpenAI mocked

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68b22325e73c833281fe7bafaf526264